### PR TITLE
Release v1.2.3

### DIFF
--- a/.docker/php-fpm-travis/Dockerfile
+++ b/.docker/php-fpm-travis/Dockerfile
@@ -1,3 +1,3 @@
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 RUN docker-php-ext-install mysqli

--- a/.docker/php-fpm-travis/php.ini
+++ b/.docker/php-fpm-travis/php.ini
@@ -1,2 +1,0 @@
-[PHP]
-memory_limit = 128M

--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -1,8 +1,25 @@
 FROM php:7.4-fpm
 
-RUN docker-php-ext-install mysqli &&\
-    pecl install xdebug && \
+# Install required packages
+RUN apt-get update && apt-get install -y \
+    zip unzip curl libmagickwand-dev libzip-dev exiftool \
+    --no-install-recommends
+
+# Install mysqli
+RUN docker-php-ext-install mysqli
+
+# Install imagick
+RUN pecl install imagick && \
+    docker-php-ext-enable imagick
+
+# Install xdebug
+RUN pecl install xdebug && \
     docker-php-ext-enable xdebug
+
+# Install other modules
+RUN pecl install exif zip && \
+    docker-php-ext-install exif && \
+    docker-php-ext-enable zip exif
 
 COPY ./xdebug.ini $PHP_INI_DIR/conf.d/
 COPY ./php.ini $PHP_INI_DIR/conf.d/

--- a/.docker/php-fpm/Dockerfile
+++ b/.docker/php-fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-fpm
+FROM php:7.4-fpm
 
 RUN docker-php-ext-install mysqli &&\
     pecl install xdebug && \

--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,9 @@ NONCE_SALT='put your unique phrase here'
 #-- END -- Main Settings --#
 
 #-- START -- Additional Settings --#
-# Enable debug
+# Enable debug and prevent errors printing
 WP_DEBUG=true
+WP_DEBUG_DISPLAY=false
 
 # Disable automatic updates of plugins, core, and themes
 AUTOMATIC_UPDATER_DISABLED=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 services: docker
 
+language: php
+
+php:
+  - '7.3'
+  - '7.4'
+
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.3",
         "roots/wordpress": "^5.0",
         "symfony/dotenv": "^5.0",
         "zippovich2/wordpress-config": "^1.1",
@@ -41,8 +41,8 @@
     },
     "require-dev": {
         "symfony/var-dumper": "^5.0",
-        "phpunit/phpunit": "^8.5",
-        "wp-cli/wp-cli-bundle": "^2.0",
+        "phpunit/phpunit": "^9.0",
+        "wp-cli/wp-cli-bundle": "^2.3",
         "guzzlehttp/guzzle": "^6.5",
         "friendsofphp/php-cs-fixer": "^2.16",
         "aaemnnosttv/wp-cli-dotenv-command": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "php": "^7.2.5",
         "roots/wordpress": "^5.0",
         "symfony/dotenv": "^5.0",
-        "zippovich2/wordpress-config": "^1.0",
+        "zippovich2/wordpress-config": "^1.1",
         "zippovich2/wordpress-loader": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
             "@move-env-file",
             "@salts",
             "rm docker-compose-travis.yaml .travis.yml",
-            "rm -rf ./docker/php-fpm-travis"
+            "rm -rf ./.docker/php-fpm-travis"
         ],
         "salts": "wp dotenv salts regenerate --file=.env --allow-root",
         "cs-check": "php-cs-fixer fix --allow-risky=yes --diff --ansi --dry-run",

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "post-create-project-cmd": [
             "@move-env-file",
             "@salts",
+            "mkdir -p ./var/log",
             "rm docker-compose-travis.yaml .travis.yml",
             "rm -rf ./.docker/php-fpm-travis"
         ],

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       XDEBUG_CONFIG: remote_host=host.docker.internal
       PROJECT_ROOT: /var/www/app
       WEB_ROOT: /var/www/app/public
+    user: "1000:1000"
 
 
   mysql:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,10 +4,11 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
          colors="true"
-         bootstrap="vendor/autoload.php">
+         bootstrap="vendor/autoload.php"
+>
     <php>
-        <ini name="error_reporting" value="-1"/>
-        <env name="APP_ENV" value="test" force="true"/>
+        <ini name="error_reporting" value="-1" />
+        <env name="APP_ENV" value="test" />
     </php>
 
     <testsuites>
@@ -21,6 +22,4 @@
             <directory>./src/</directory>
         </whitelist>
     </filter>
-
-
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,7 +2,7 @@
 
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          colors="true"
          bootstrap="vendor/autoload.php"
 >
@@ -17,9 +17,9 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
**Changes:**

- Fixed bug in post-create-project-cmd composer hook - now it delete `./.docker/php-fpm-travis` directory.
- Updated docker php version to 7.4.
- Updated dependecies.
- Fixed some WordPress Site Health errors and warnings.
- Fixed composer warnings.
- Set docker php-fpm container user UID to 1000 to prevent files permission errors.